### PR TITLE
Fix 'Edit on GitHub' link

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,6 @@
 site_name: Bloom Handbook
 repo_url: https://github.com/Bloom-Works/handbook/
+edit_uri: edit/main/docs
 site_url: https://bloom-handbook.rtfd.io/
 theme:
   name: readthedocs


### PR DESCRIPTION
The link, by default from mkdocs, pointed to the old (not inclusive) GitHub convention of `master` branch. This quick fix changes it to point to the `main` branch that we're using instead as the default branch.